### PR TITLE
Fix blobbi spawning at center when exiting a room

### DIFF
--- a/src/components/blobbi/PlayingView.tsx
+++ b/src/components/blobbi/PlayingView.tsx
@@ -56,7 +56,7 @@ export function PlayingView({ selectedBlobbi }: PlayingViewProps) {
   // the local player when it walks (or, later, emotes/acts) nearby.
   const localActiveRef = useRef<LocalActiveState | null>(null);
   const chatFunctionRef = useRef<((text: string) => Promise<void>) | null>(null);
-  const { currentLocation } = useLocation();
+  const { currentLocation, previousLocation } = useLocation();
   const { nostr } = useNostr();
   const { showDebugOverlays } = useDebugOverlays();
   const [modalKey, setModalKey] = useState<string>('self');
@@ -107,7 +107,7 @@ export function PlayingView({ selectedBlobbi }: PlayingViewProps) {
 
   const background = getBackgroundForLocation(currentLocation);
   const blobbiSize = getBlobbiSizeForLocation(currentLocation);
-  const blobbiInitialPosition = getBlobbiInitialPosition(currentLocation);
+  const blobbiInitialPosition = getBlobbiInitialPosition(currentLocation, previousLocation);
   const [myPosition, setMyPosition] = useState<Position>(blobbiInitialPosition);
   const boundary = locationBoundaries[background] || {
     shape: 'rectangle',

--- a/src/contexts/LocationContext.tsx
+++ b/src/contexts/LocationContext.tsx
@@ -8,6 +8,7 @@ interface LocationProviderProps {
 
 export function LocationProvider({ children }: LocationProviderProps) {
   const [currentLocation, setCurrentLocation] = useState<LocationId>('town');
+  const [previousLocation, setPreviousLocation] = useState<LocationId | null>(null);
   const [isMapModalOpen, setIsMapModalOpen] = useState(false);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const transitionTimeout = useRef<NodeJS.Timeout | null>(null);
@@ -18,6 +19,7 @@ export function LocationProvider({ children }: LocationProviderProps) {
     }
     setIsTransitioning(true);
     transitionTimeout.current = setTimeout(() => {
+      setPreviousLocation(currentLocation);
       setCurrentLocation(location);
 
       // Clear arcade pass when leaving arcade locations
@@ -53,6 +55,7 @@ export function LocationProvider({ children }: LocationProviderProps) {
       value={{
         currentLocation,
         setCurrentLocation: transitionToLocation,
+        previousLocation,
         isMapModalOpen,
         setIsMapModalOpen,
         isTransitioning,

--- a/src/contexts/LocationContextValue.ts
+++ b/src/contexts/LocationContextValue.ts
@@ -4,6 +4,7 @@ import type { LocationId } from '@/lib/location-types';
 interface LocationContextType {
   currentLocation: LocationId;
   setCurrentLocation: (location: LocationId) => void;
+  previousLocation: LocationId | null;
   isMapModalOpen: boolean;
   setIsMapModalOpen: (open: boolean) => void;
   isTransitioning: boolean;

--- a/src/lib/location-initial-position.ts
+++ b/src/lib/location-initial-position.ts
@@ -24,8 +24,45 @@ export const LOCATION_INITIAL_POSITIONS: Record<LocationId, InitialPosition> = {
   'clothing-store-inside': { x: 50, y: 80 },
 };
 
-export function getBlobbiInitialPosition(location: string): InitialPosition {
-  const defaultPosition = LOCATION_INITIAL_POSITIONS[location] || { x: 50, y: 75 };
+/**
+ * Maps a child location to the position near its door on the parent location.
+ * Key format: "parentLocation:childLocation" → position near the child's door on the parent map.
+ * Used when exiting a room so the blobbi appears near the door they just came out of,
+ * instead of the default center position.
+ */
+const EXIT_POSITIONS: Record<string, InitialPosition> = {
+  // Exiting to town from various rooms
+  'town:arcade': { x: 32, y: 68 },
+  'town:stage': { x: 58, y: 65 },
+  'town:shop': { x: 68, y: 68 },
+
+  // Exiting to nostr-station area from nostr-station-inside
+  'nostr-station:nostr-station-inside': { x: 80, y: 40 },
+
+  // Exiting to plaza from plaza-inside
+  'plaza:plaza-inside': { x: 50, y: 60 },
+
+  // Exiting to shop (mall) from clothing-store-inside
+  'shop:clothing-store-inside': { x: 55, y: 40 },
+
+  // Exiting to mine from cave-open
+  'mine:cave-open': { x: 50, y: 70 },
+
+  // Exiting to home from back-yard
+  'home:back-yard': { x: 78, y: 75 },
+};
+
+export function getBlobbiInitialPosition(location: string, previousLocation?: string | null): InitialPosition {
+  // If we have a previous location, try to find an exit position near the door
+  if (previousLocation) {
+    const exitKey = `${location}:${previousLocation}`;
+    const exitPosition = EXIT_POSITIONS[exitKey];
+    if (exitPosition) {
+      return exitPosition;
+    }
+  }
+
+  const defaultPosition = LOCATION_INITIAL_POSITIONS[location as LocationId] || { x: 50, y: 75 };
 
   if (location === 'arcade') {
     const hasArcadePass = sessionStorage.getItem('has-arcade-pass') === 'true';


### PR DESCRIPTION
Currently, if the blobbi enters a room and then leaves it, instead of being close to the door of the room he had just left, the blobbi is moved to his default map location.   

Take for example this default location of the **Town**
<img width="1148" height="781" alt="image" src="https://github.com/user-attachments/assets/8630b920-9c40-4f8c-9ba6-d8cd9994695a" />   

When I enter the Village Shop:  
<img width="1148" height="781" alt="image" src="https://github.com/user-attachments/assets/673484b4-f117-4a0b-926b-a498726a7c93" />   

Now when I leave it, the blobbi will be close to the door:  
<img width="1148" height="781" alt="image" src="https://github.com/user-attachments/assets/3697d258-3a2e-4887-aafd-ca3634a7b740" />

That's what this code does.

